### PR TITLE
Add standardized GitHub Actions and pkgdown

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,0 +1,36 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+name: R-CMD-check
+
+permissions:
+  contents: read
+
+jobs:
+  R-CMD-check:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ github.token }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: release
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/R-Wasm-check.yaml
+++ b/.github/workflows/R-Wasm-check.yaml
@@ -1,0 +1,26 @@
+# Workflow derived from https://github.com/r-wasm/actions/tree/v3/examples
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+name: R-Wasm-check
+
+permissions:
+  contents: read
+
+jobs:
+  R-Wasm-check:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ github.token }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Build package for WebAssembly
+        uses: r-wasm/actions/build-rwasm@v3
+        with:
+          packages: "."

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,46 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  release:
+    types: [published]
+  workflow_dispatch:
+
+name: pkgdown
+
+permissions:
+  contents: write
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ github.token }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: release
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
+
+      - name: Build site
+        shell: Rscript {0}
+        run: pkgdown::build_site()
+
+      - name: Deploy site
+        if: github.event_name != 'pull_request'
+        run: |
+          git config --local user.name "$GITHUB_ACTOR"
+          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,27 @@
+url: https://jkunst.com/figletr/
+
+authors:
+  Joshua Kunst:
+    href: https://jkunst.com
+
+lang: en
+
+template:
+  bootstrap: 5
+  bslib:
+    primary: "#6F42C1"
+    border-radius: 0.5rem
+    btn-border-radius: 0.25rem
+    base_font:
+      google: "IBM Plex Sans"
+    heading_font:
+      google: "IBM Plex Sans"
+    code_font:
+      google: "Fira Mono"
+    headings-color: "#2A2433"
+    headings-line-height: 1.2
+    headings-margin-bottom: 0.75rem
+
+navbar:
+  bg: primary
+  type: dark


### PR DESCRIPTION
## Summary

- add the shared R-CMD-check workflow on Ubuntu with R release
- add the shared pkgdown build and deployment workflow
- use actions/checkout@v5 consistently
- add a WebAssembly package build with r-wasm/actions/build-rwasm@v3
- add a Bootstrap 5 pkgdown configuration with a restrained typographic identity

## Scope

Infrastructure and pkgdown styling only. No package logic was changed.

## Checks

- R-CMD-check
- pkgdown build
- WebAssembly package build
